### PR TITLE
Fix copy-button overlap on short code blocks without dead space

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -110,10 +110,18 @@ const facebookShareLink = `https://www.facebook.com/sharer/sharer.php?u=${encode
 	// via set:html, which never carry the scoped style attribute either.
 	.caption-post pre {
 		position: relative;
-		// Extra top padding keeps the copy button (top:0; right:0) from
-		// overlapping short, single-line snippets.
-		padding: rem(56px) rem(16px) rem(16px);
+		padding: rem(16px);
 		border-radius: var(--radius-8);
 		overflow-x: auto;
+
+		// Reserve room for the copy button (top:0; right:0) on the first
+		// line only, instead of padding the whole block — otherwise every
+		// code block gets a dead gap up top regardless of how short it is.
+		code > .line:first-child {
+			display: inline-block;
+			box-sizing: border-box;
+			width: 100%;
+			padding-right: rem(48px);
+		}
 	}
 </style>


### PR DESCRIPTION
The earlier fix (reserving a 56px top padding on every code block) solved the button-overlaps-short-snippet problem but left a big empty gap above every code block regardless of how long it was. Instead, reserve horizontal room only on the code's first rendered line (Shiki wraps each line in its own span), stretched to the block's full width via display:inline-block so its own padding-right creates real clearance up to where the button sits — verified with a Range over the actual text nodes (not just the line's bounding box) that no code block's rendered glyphs reach under the button.