### PR TITLE
Lazy-load Swiper in Carousel; add Tab focus-trap to Modal

### DIFF
--- a/src/lib/components/Carousel.astro
+++ b/src/lib/components/Carousel.astro
@@ -132,30 +132,50 @@ const swiperConfig = JSON.stringify({
 </style>
 
 <script>
-	import { register } from 'swiper/element';
-	import { Pagination } from 'swiper/modules';
-	import paginationStyles from 'swiper/element/css/pagination?raw';
 	import type { SwiperContainer } from 'swiper/element';
 
-	function initCarousels(): void {
+	let observer: IntersectionObserver | null = null;
+
+	// Swiper's own JS (register/Pagination/pagination CSS) is only fetched
+	// once a carousel actually scrolls into view, matching the deferred-load
+	// behavior client:visible used to give us before this went pure Astro.
+	async function loadAndInitSwiper(swiperEl: SwiperContainer): Promise<void> {
+		const [{ register }, { Pagination }, { default: paginationStyles }] = await Promise.all([
+			import('swiper/element'),
+			import('swiper/modules'),
+			import('swiper/element/css/pagination?raw')
+		]);
+
 		// swiper/element's register() already no-ops if the custom elements
-		// are defined, so calling it again on every astro:page-load is safe.
+		// are defined, so calling it again for every lazily-loaded carousel is safe.
 		register();
+
+		const config = JSON.parse(swiperEl.getAttribute('data-swiper-config') ?? '{}');
+		Object.assign(swiperEl, {
+			modules: [Pagination],
+			injectStyles: [paginationStyles],
+			...config
+		});
+		swiperEl.initialize();
+		swiperEl.setAttribute('data-swiper-ready', 'true');
+	}
+
+	function initCarousels(): void {
+		observer?.disconnect();
+		observer = new IntersectionObserver((entries) => {
+			entries.forEach((entry) => {
+				if (!entry.isIntersecting) return;
+				const swiperEl = entry.target as SwiperContainer;
+				observer?.unobserve(swiperEl);
+				loadAndInitSwiper(swiperEl);
+			});
+		});
 
 		document
 			.querySelectorAll<SwiperContainer>(
 				'swiper-container[data-swiper-config]:not([data-swiper-ready])'
 			)
-			.forEach((swiperEl) => {
-				const config = JSON.parse(swiperEl.getAttribute('data-swiper-config') ?? '{}');
-				Object.assign(swiperEl, {
-					modules: [Pagination],
-					injectStyles: [paginationStyles],
-					...config
-				});
-				swiperEl.initialize();
-				swiperEl.setAttribute('data-swiper-ready', 'true');
-			});
+			.forEach((swiperEl) => observer?.observe(swiperEl));
 	}
 
 	document.addEventListener('astro:page-load', initCarousels);

--- a/src/lib/components/Modal.astro
+++ b/src/lib/components/Modal.astro
@@ -103,9 +103,38 @@ const modalId = `review-modal-${index}`;
 		lastFocusedTrigger?.focus();
 	}
 
+	function getFocusableElements(modal: HTMLElement): HTMLElement[] {
+		return Array.from(
+			modal.querySelectorAll<HTMLElement>(
+				'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])'
+			)
+		).filter((el) => el.offsetParent !== null);
+	}
+
 	function handleKeydown(event: KeyboardEvent): void {
-		if (event.key !== 'Escape') return;
-		document.querySelectorAll<HTMLElement>('[data-modal]:not([hidden])').forEach(closeModal);
+		const openModal = document.querySelector<HTMLElement>('[data-modal]:not([hidden])');
+		if (!openModal) return;
+
+		if (event.key === 'Escape') {
+			closeModal(openModal);
+			return;
+		}
+
+		if (event.key !== 'Tab') return;
+
+		// Trap focus inside the modal while it's open.
+		const focusable = getFocusableElements(openModal);
+		if (focusable.length === 0) return;
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+
+		if (event.shiftKey && document.activeElement === first) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && document.activeElement === last) {
+			event.preventDefault();
+			first.focus();
+		}
 	}
 
 	function initModals(): void {


### PR DESCRIPTION
## Summary
- Carousel: converting away from `client:visible` dropped the built-in deferred loading — Swiper's JS was being imported eagerly on every page load regardless of scroll position. Restored the original behavior with an `IntersectionObserver` that only dynamically imports `swiper/element`, `swiper/modules`, and the pagination CSS once a carousel actually scrolls into view.
- Modal: `Tab`/`Shift+Tab` now cycle focus within the open modal instead of escaping to the page behind it, matching standard dialog behavior. This gap existed in the original Svelte version too, not a regression from the Astro port — fixed while already in this code.

## Test plan
- [x] `bun run check` / `bun run lint` clean
- [x] `bun run build` — confirmed Carousel's own script chunk dropped to ~1KB, Swiper's ~87KB now in separate chunks with no `modulepreload` hint
- [x] Verified in browser: on initial load (carousels below the fold) neither `swiper-container` initializes; manually invoking the same dynamic-import path the built chunk uses renders the carousel correctly
- [x] Modal Tab/Shift+Tab keeps focus on the single focusable element (close button) instead of escaping; Escape and click-outside still close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)