### PR TITLE
Load Google Fonts stylesheet asynchronously

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,10 +39,28 @@ const isBlogSubpage = currentPath.startsWith('/blog/');
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<!--
+			Loaded async (preload + swap to `all` media on load) so the
+			request to Google's CDN doesn't block first paint — font-display:
+			swap already avoids invisible text either way.
+		-->
+		<link
+			rel="preload"
+			as="style"
+			href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap"
+		/>
 		<link
 			rel="stylesheet"
 			href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap"
+			media="print"
+			onload="this.media='all'"
 		/>
+		<noscript>
+			<link
+				rel="stylesheet"
+				href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap"
+			/>
+		</noscript>
 		<link rel="apple-touch-icon" sizes="180x180" href={`/apple-touch-icon.png?v=${buildVersion}`} />
 		<link rel="icon" type="image/png" sizes="32x32" href={`/favicon-32x32.png?v=${buildVersion}`} />
 		<link rel="icon" type="image/png" sizes="16x16" href={`/favicon-16x16.png?v=${buildVersion}`} />


### PR DESCRIPTION
## Summary
- Lighthouse flagged the Google Fonts stylesheet as render-blocking (890ms round-trip for a 0.7KB file). Switched to the standard preload + `media=print`/`onload=all` swap pattern so it no longer blocks first paint.
- `font-display: swap` was already set, so there's no behavior change around invisible text — this only removes the render-blocking network wait.
- `<noscript>` fallback keeps the font loading for users without JS.

## Test plan
- [x] `bun run check` / `bun run lint` clean
- [x] `bun run build` — confirmed output HTML has the preload + swap link + noscript fallback
- [x] Verified in browser: `link.media` swaps to `"all"` after load, and Poppins is actually applied (`getComputedStyle` on body/sidebar name both show `Poppins, sans-serif`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)