### PR TITLE
Serve the sidebar avatar as a responsive image

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,5 @@
 ---
 import '../app.scss';
-import { getImage } from 'astro:assets';
 import { ClientRouter } from 'astro:transitions';
 import Analytics from '@vercel/analytics/astro';
 import SpeedInsights from '@vercel/speed-insights/astro';
@@ -11,8 +10,6 @@ import Sidebar from '$lib/components/Sidebar.astro';
 import PageTitle from '$lib/components/PageTitle.astro';
 import ScrollIndicator from '$lib/components/ScrollIndicator.astro';
 import headshot from '#images/headshot.webp';
-
-const avatar = await getImage({ src: headshot, width: 400, height: 400 });
 
 // Cache-bust static files served as-is from public/ (favicons, manifest,
 // resume PDF) that Astro/Vite don't fingerprint the way it does bundled
@@ -76,12 +73,7 @@ const isBlogSubpage = currentPath.startsWith('/blog/');
 		<main class="main">
 			<div class="container gutter-top gutter-bottom">
 				<div class="row sticky-parent">
-					<Sidebar
-						avatarSrc={avatar.src}
-						avatarWidth={avatar.attributes.width}
-						avatarHeight={avatar.attributes.height}
-						{cvHref}
-					/>
+					<Sidebar avatarSrc={headshot} {cvHref} />
 					<div class="col-12 col-md-12 col-xl-9">
 						<div class="box-outer">
 							<NavBar {links} {currentPath} />

--- a/src/lib/components/Sidebar.astro
+++ b/src/lib/components/Sidebar.astro
@@ -1,19 +1,17 @@
 ---
+import { Image } from 'astro:assets';
 import Button from '$lib/components/Button.svelte';
+import type { ImageMetadata } from 'astro';
 import type { PersonalInfo as PersonalInfoType } from '#types/PersonalInfo';
 
 interface Props {
-	avatarSrc: string;
-	avatarWidth: number;
-	avatarHeight: number;
+	avatarSrc: ImageMetadata;
 	cvHref?: string;
 	personalInfo?: PersonalInfoType;
 }
 
 const {
 	avatarSrc,
-	avatarWidth,
-	avatarHeight,
 	cvHref = '/David_Guras_resume.pdf',
 	personalInfo = {
 		name: 'David Guras',
@@ -49,7 +47,14 @@ function isLocalLink(target: string): { target?: string; rel?: string } {
 		<!-- My photo -->
 		<div class="sidebar__base-info">
 			<figure class="avatar-box">
-				<img src={avatarSrc} width={avatarWidth} height={avatarHeight} alt={personalInfo.name} />
+				<Image
+					src={avatarSrc}
+					alt={personalInfo.name}
+					width={240}
+					height={240}
+					layout="constrained"
+					priority
+				/>
 			</figure>
 
 			<div class="copy-box">


### PR DESCRIPTION
## Summary
Lighthouse flagged the sidebar avatar as larger than its displayed size (400x400 served, ~240x240 displayed on desktop — 10KB wasted). The avatar box is fluid (scales with a flexible sidebar column), so a single fixed export can't really be "correct" for every breakpoint.

Replaced the manual `getImage()` + plain `<img>` with Astro's `<Image>` component using `layout="constrained"`, which generates a real `srcset` (240w/480w) + `sizes` attribute so the browser picks an appropriately-sized variant instead of always downloading the same file regardless of viewport or pixel density.

Kept `priority` set since this avatar is always above the fold — Astro's `<Image>` defaults to `loading="lazy"`, which would have been a regression for a sidebar image visible on first paint.

## Test plan
- [x] `bun run check` / `bun run lint` clean
- [x] `bun run build` — confirmed two image variants generated (240w ~8KB, 480w ~20KB) instead of one fixed 400x400 (~15.6KB)
- [x] Verified in browser: rendered `<img>` has correct `srcset`/`sizes`; on a DPR-2 display `img.currentSrc` correctly resolves to the 480w variant; visually identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)