### PR TITLE
Replace AI-Orchestrated Development card icon with a sparkle glyph

### DIFF
--- a/public/images/icons/icon-sparkle.svg
+++ b/public/images/icons/icon-sparkle.svg
@@ -1,0 +1,14 @@
+<svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 2C12.6 8 14.6 10.6 20.5 12C14.6 13.4 12.6 16 12 22C11.4 16 9.4 13.4 3.5 12C9.4 10.6 11.4 8 12 2Z" fill="url(#paint0_linear)"/>
+<path d="M19 2C19.3 3.9 20.1 4.9 22 5.5C20.1 6.1 19.3 7.1 19 9C18.7 7.1 17.9 6.1 16 5.5C17.9 4.9 18.7 3.9 19 2Z" fill="url(#paint1_linear)"/>
+<defs>
+<linearGradient id="paint0_linear" x1="3.5" y1="2" x2="20.5" y2="22" gradientUnits="userSpaceOnUse">
+<stop offset="0.259336" stop-color="#FFDB6E"/>
+<stop offset="1" stop-color="#FFBC5E"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="16" y1="2" x2="22" y2="9" gradientUnits="userSpaceOnUse">
+<stop offset="0.259336" stop-color="#FFDB6E"/>
+<stop offset="1" stop-color="#FFBC5E"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,7 +32,7 @@ const expertise: ExpertiseType = {
 		},
 		{
 			name: 'AI-Orchestrated Development',
-			icon: '/images/icons/icon-app.svg',
+			icon: '/images/icons/icon-sparkle.svg',
 			iconAlt: 'AI-Orchestrated Development',
 			description: 'Directing AI coding agents to design, build, and ship production web apps.'
 		}


### PR DESCRIPTION
## Summary
The "AI-Orchestrated Development" expertise card was using `icon-app.svg` (a smartphone icon) — a mismatch left over from when it replaced the Cybersecurity card. Added a new `icon-sparkle.svg`, using the same two-stop gold gradient (`#FFDB6E` → `#FFBC5E`) as the rest of the icon set, in the sparkle motif that's become the standard visual shorthand for "AI-powered" across the industry.

## Test plan
- [x] `bun run check` / `bun run lint` clean
- [x] `bun run build` succeeds
- [x] Verified visually in browser — icon renders cleanly, matches the gold gradient of the other three cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)